### PR TITLE
Windows build compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,20 @@ ZMQ_BASE_BUILD_DIR = $(CURDIR)/libzmq/build
 ZMQ_BUILD_DIR = $(ZMQ_BASE_BUILD_DIR)/v$(ZMQ_VERSION)
 ZMQ_PKG_CONFIG_DIR = $(ZMQ_BUILD_DIR)/lib/pkgconfig
 ifeq ($(OS),Windows_NT)
-ZMQ_COMPILE_HOST ?= x86_64-w64-mingw32
-CXXFLAGS="-static-libgcc -static-libstdc++"
-SHARED_EXT := .dll
+ZMQ_BUILD_HOST ?= x86_64-w64-mingw32
 else
-ZMQ_COMPILE_HOST ?=
-CXXFLAGS=""
-SHARED_EXT := .so
+ZMQ_BUILD_HOST ?=
 endif
 $(shell touch version)
 endif
+endif
+
+ifneq (,$(findstring "mingw", $(ZMQ_BUILD_HOST)))
+CXXFLAGS="-static-libgcc -static-libstdc++"
+SHARED_EXT := .dll
+else
+CXXFLAGS=""
+SHARED_EXT := .so
 endif
 
 SHARED := emacs-zmq$(SHARED_EXT)
@@ -106,3 +110,6 @@ endif
 	./configure CXXFLAGS=$(CXXFLAGS) --quiet --without-docs --prefix=$(ZMQ_BUILD_DIR) \
 		--enable-drafts=yes --enable-libunwind=no --enable-static=no && \
 	$(MAKE) install
+ifeq ($(OS),Windows_NT)
+	cp $(ZMQ_BUILD_DIR)/bin/libzmq.dll $(CURDIR)
+endif

--- a/README.org
+++ b/README.org
@@ -32,6 +32,38 @@ the environment variable =ZMQ_VERSION=, e.g. to something like
 ZMQ_VERSION=4.3.0
 #+END_SRC
 
+*** Windows
+
+It is possible to use the included build chain on Windows using the [[https://www.msys2.org/][MSYS2]] MinGW
+tools.
+
+Install the 64-bit toolchain inside the MSYS2 shell via
+#+BEGIN_SRC shell
+pacman -S base-devel
+pacman -S git
+pacman -S mingw-w64-x86_64-gcc
+#+END_SRC
+
+Note: If you are using the official Git for Windows instead of MSYS2 Git, make
+sure to set
+
+#+BEGIN_SRC shell
+git config --global core.autocrlf false
+#+END_SRC
+
+during the build to avoid EOL issues and set it back to =true= (the default on
+Windows) when you are done building.
+
+Start the build from an MSYS2 MinGW 64-bit shell via =make=.
+
+The =libzmq.dll= is built to =libzmq/build/v*/bin= and needs to be copied to the
+top level directory next to the =emacs-zmq.dll= to be found by the Windows DLL
+lookup machinery.
+
+Note that you need to have Emacs compiled =--with-modules= to be able to load
+shared modules. See instructions [[https://sourceforge.net/p/emacsbinw64/wiki/Build%2520guideline%2520for%2520MSYS2-MinGW-w64%2520system/][here]] for a way to do this using the mentioned
+tools.
+
 ** Testing
 
 Run =make test= in the top level directory.

--- a/README.org
+++ b/README.org
@@ -56,12 +56,8 @@ Windows) when you are done building.
 
 Start the build from an MSYS2 MinGW 64-bit shell via =make=.
 
-The =libzmq.dll= is built to =libzmq/build/v*/bin= and needs to be copied to the
-top level directory next to the =emacs-zmq.dll= to be found by the Windows DLL
-lookup machinery.
-
 Note that you need to have Emacs compiled =--with-modules= to be able to load
-shared modules. See instructions [[https://sourceforge.net/p/emacsbinw64/wiki/Build%2520guideline%2520for%2520MSYS2-MinGW-w64%2520system/][here]] for a way to do this using the mentioned
+shared modules. See instructions [[https://sourceforge.net/p/emacsbinw64/wiki/Build%20guideline%20for%20MSYS2-MinGW-w64%20system/][here]] for a way to do this using the mentioned
 tools.
 
 ** Testing

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
 lib_LTLIBRARIES = emacs-zmq.la
-emacs_zmq_la_LDFLAGS = -module -avoid-version
+emacs_zmq_la_LDFLAGS = -module -avoid-version $(EXTRA_LDFLAGS)
 emacs_zmq_la_SOURCES = socket.c context.c msg.c constants.c util.c core.c poll.c emacs-zmq.c
 emacs_zmq_la_CFLAGS = -pthread -O3

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -29,11 +29,13 @@ AC_SEARCH_LIBS([zmq_poller_new], [zmq],
 AC_CANONICAL_HOST
 if test "$host_os" = mingw32
 then
-    EXTRA_LDFLAGS="-no-undefined"
+  EXTRA_LDFLAGS="-no-undefined"
+  LT_INIT([win32-dll disable-static])
+else
+  EXTRA_LDFLAGS=""
+  LT_INIT([shared disable-static])
 fi
 AC_SUBST([EXTRA_LDFLAGS])
-
-LT_INIT([win32-dll disable-static])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -26,7 +26,14 @@ AC_SEARCH_LIBS([zmq_poller_new], [zmq],
   [AC_MSG_ERROR([libzmq not built with DRAFT API or libzmq is not usable.])
 ])
 
-LT_INIT([shared disable-static])
+AC_CANONICAL_HOST
+if test "$host_os" = mingw32
+then
+    EXTRA_LDFLAGS="-no-undefined"
+fi
+AC_SUBST([EXTRA_LDFLAGS])
+
+LT_INIT([win32-dll disable-static])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -30,11 +30,10 @@ AC_CANONICAL_HOST
 if test "$host_os" = mingw32
 then
   EXTRA_LDFLAGS="-no-undefined"
-  LT_INIT([win32-dll disable-static])
 else
   EXTRA_LDFLAGS=""
-  LT_INIT([shared disable-static])
 fi
+LT_INIT([win32-dll shared disable-static])
 AC_SUBST([EXTRA_LDFLAGS])
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
Build binaries using the MinGW toolchain following the suggestions in https://github.com/dzop/emacs-zmq/issues/3.

I am new to autotools so please review accordingly. It Works Over Here and existing Travis builds succeed.

Next step would be to integrate this into Travis using the release uploading feature.

Let me know in case you want this squashed.

Fixes https://github.com/dzop/emacs-zmq/issues/3