### PR TITLE
Remove zmq-load

### DIFF
--- a/zmq.el
+++ b/zmq.el
@@ -688,8 +688,6 @@ Emacs process."
                     (recursive-edit)))))))
       (user-error "Modules are not supported"))))
 
-(zmq-load)
-
 (provide 'zmq)
 
 ;; Local Variables:


### PR DESCRIPTION
Hi!

This package will be prompted during `package-install` for this top-level `zmq-load`.
This requires me to respond when installing more than 100 packages, making batch installation difficult.