### PR TITLE
update zmq-module-file to support native-comp

### DIFF
--- a/zmq.el
+++ b/zmq.el
@@ -461,7 +461,7 @@ Emacs process."
   (cl-destructuring-bind (min . max) (func-arity sexp)
     (unless (and (<= min 1) (or (not (numberp max)) (<= max 1)))
       (error "Invalid function to send to process, can only have 0 or 1 arguments")))
-  (let* ((zmq-path (locate-library "zmq"))
+  (let* ((zmq-path (locate-library "zmq.el"))
          (cmd (format "(zmq--init-subprocess %s)" (when debug t)))
          ;; stderr is split from stdout since the former is used by
          ;; Emacs to print messages that we don't want intermixed
@@ -625,7 +625,7 @@ Emacs process."
   ;; Assume the module is already loaded when one of its functions is defined.
   (unless (functionp #'zmq--cleanup-globrefs)
     (if module-file-suffix
-        (let ((default-directory (file-name-directory (locate-library "zmq"))))
+        (let ((default-directory (file-name-directory (locate-library "zmq.el"))))
           (if (load (expand-file-name "emacs-zmq") t)
               (add-hook 'post-gc-hook #'zmq--cleanup-globrefs)
             ;; Can also be "latest"


### PR DESCRIPTION
The .eln files created by the native compile feature are not located in the same folder as the .el and .elc files they are derived from. This means that using (locate-library "zmq") to find the right folder for `zmq-module-file` breaks because it returns something like "/home/tom/.emacs.d/elpa/zmq-20200305.2345/eln-x86_64-pc-linux-gnu-b95c8552e0bc9ba5/zmq.eln" instead of "/home/tom/.emacs.d/elpa/zmq-20200305.2345/zmq.el". Using (locate-library "zmq.el") instead fixes the issue.

Similar issue with elpy https://github.com/jorgenschaefer/elpy/pull/1811.