### PR TITLE
Detect and use the appropriate Emacs module suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ EZMQ_LIBDIR ?= $(CURDIR)/$(ZMQ_BUILD_HOST)
 # to point to the ZMQ to build with.
 
 # Get the module extension for this build
+EMACS_EXT := $(shell $(EMACS) --batch --eval "(princ (and (boundp 'module-file-suffix) module-file-suffix))")
+ifeq ($(EMACS_EXT), nil)
+$(error No module support in $(EMACS))
+endif
+
 ifeq ($(ZMQ_BUILD_HOST),)
 ifneq (,$(or $(findstring MSYS, $(MSYSTEM)), \
 			 $(findstring MINGW, $(MSYSTEM))))
@@ -34,9 +39,10 @@ endif
 endif
 
 SHARED := emacs-zmq$(SHARED_EXT)
+SHARED_EMACS := emacs-zmq$(EMACS_EXT)
 
 .PHONY: all
-all: $(EZMQ_LIBDIR)/$(SHARED) compile
+all: $(EZMQ_LIBDIR)/$(SHARED_EMACS) compile
 
 .PHONY: configure
 configure: src/configure
@@ -46,10 +52,10 @@ configure: src/configure
 		--without-docs --enable-drafts=yes --enable-libunwind=no \
 		--disable-curve-keygen --disable-perf --disable-eventfd
 
-$(EZMQ_LIBDIR)/$(SHARED): src/Makefile
+$(EZMQ_LIBDIR)/$(SHARED_EMACS): src/Makefile
 	$(MAKE) -C src
 	mkdir -p $(EZMQ_LIBDIR)
-	cp src/.libs/$(SHARED) $(EZMQ_LIBDIR)/$(SHARED)
+	cp src/.libs/$(SHARED) $(EZMQ_LIBDIR)/$(SHARED_EMACS)
 
 src/Makefile: src/configure
 	$(MAKE) configure

--- a/zmq.el
+++ b/zmq.el
@@ -42,11 +42,7 @@
 (defconst zmq-module-file
   (when module-file-suffix
     (expand-file-name
-     ;; module-file-suffix may be ".dylib" starting Emacs 28, but
-     ;; libtool module is still built as ".so"
-     (concat
-      "emacs-zmq"
-      (if (string= module-file-suffix ".dylib") ".so" module-file-suffix))
+     (concat "emacs-zmq" module-file-suffix)
      (file-name-directory (locate-library "zmq"))))
   "The module file for ZMQ or nil if modules are not supported.")
 


### PR DESCRIPTION
In different versions of Emacs (for example from 27 to 28 on Mac OS)
the value of module-file-suffix can change. We just directly detect
and use it for the dynamic library filename.

This is more robust than simply ignoring the suffix, as was done previously.