### PR TITLE
zmq-load: correctly handle binary data

### DIFF
--- a/zmq.el
+++ b/zmq.el
@@ -568,12 +568,14 @@ Emacs process."
   (cond
    ((and (executable-find "curl")
          ;; -s = silent, -L = follow redirects
-         (zerop (call-process "curl" nil (current-buffer) nil
-                              "-s" "-L" url))))
+         (let ((default-process-coding-system '(binary . binary)))
+           (zerop (call-process "curl" nil (current-buffer) nil
+                                "-s" "-L" url)))))
    ((and (executable-find "wget")
          ;; -q = quiet, -O - = output to stdout
-         (zerop (call-process "wget" nil (current-buffer) nil
-                              "-q" "-O" "-" url))))
+         (let ((default-process-coding-system '(binary . binary)))
+           (zerop (call-process "wget" nil (current-buffer) nil
+                                "-q" "-O" "-" url)))))
    (t
     (require 'url-handlers)
     (let ((buf (url-retrieve-synchronously url)))
@@ -582,6 +584,7 @@ Emacs process."
 (defmacro zmq--download-url (url &rest body)
   (declare (indent 1))
   `(with-temp-buffer
+     (set-buffer-multibyte nil)
      (zmq--insert-url-contents ,url)
      (goto-char (point-min))
      ,@body))


### PR DESCRIPTION
Set the buffer, and process I/O, coding systems to handle binary
data correctly while downloading pre-built modules.

The most important part is the process coding system handling
in the hand-written URL download functions.  Without that there
will be corruption on any platform where line endings are modified
by default, and binary data is accessed.

This is only required, of course, using external processes
to download content into the buffer.  The `url` package
handles encoded data correctly without help.

Setting the buffer unibyte is not strictly required, as the current set
of functions that interact with it are safe.  This avoids the risk that
the content will be misinterpreted as a text encoding later.

This fixes #15 and https://github.com/nnicandro/emacs-jupyter/issues/214