### PR TITLE
Return NULL for nil object in ezmq_extract_obj

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -151,6 +151,9 @@ ezmq_obj_of_type(emacs_value val, enum ezmq_obj_t type)
 ezmq_obj_t *
 ezmq_extract_obj(enum ezmq_obj_t type, emacs_value val)
 {
+    if (!env->is_not_nil(env, val)) {
+      return NULL;
+    }
     ezmq_obj_t *obj = USER_PTR(val);
     if(!NONLOCAL_EXIT()) {
         if(USER_FINALIZER(val) == &ezmq_obj_finalizer) {


### PR DESCRIPTION
`ezmq_extract_obj` fails when the object can be `nil`.

For example, when `ezmq_proxy` is invoked without a third argument, or equivalently, with `nil` as its third argument, as in `(zmq-proxy frontend backend nil)`, we get:

```elisp
Debugger entered--Lisp error: (wrong-type-argument user-ptrp nil)
  zmq-proxy(#<user-ptr ptr=0x100d44e80 finalizer=0x101b6ef30> #<user-ptr ptr=0x101a34610 finalizer=0x101b6ef30> nil)
  (let* ((context (zmq-context)) (frontend (zmq-socket context zmq-ROUTER)) (backend (zmq-socket context zmq-DEALER))) (zmq-bind frontend "tcp://*:5559") (zmq-bind backend "tcp://*:5560") (zmq-proxy frontend backend nil))
  eval-buffer(#<buffer  *load*> nil "/Users/ashwin/workspace/github/shwina/emacs-zmq-examples/extended-request-reply/broker.el" nil t)  ; Reading at buffer position 317
  load-with-code-conversion("/Users/ashwin/workspace/github/shwina/emacs-zmq-examples/extended-request-reply/broker.el" "/Users/ashwin/workspace/github/shwina/emacs-zmq-examples/extended-request-reply/broker.el" nil t)
  load("/Users/ashwin/workspace/github/shwina/emacs-zmq-examples/extended-request-reply/broker.el" nil t t)
  command-line-1(("-scriptload" "broker.el"))
  command-line()
  normal-top-level()
```

This PR makes it so that `ezmq_extract_obj` returns `NULL` when the Lisp object is `nil`. 