### PR TITLE
Do not export unnecessary symbols in dynamic library

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ if ZMQ_BUILD_LOCALLY
 # Its necessary to pass static libraries directly to the linker since libtool
 # won't build emacs-zmq as a dynamic module on Windows otherwise.
 emacs_zmq_la_LDFLAGS += -Wl,libzmq/src/.libs/libzmq.a
-emacs_zmq_la_CFLAGS += -Ilibzmq/include
+emacs_zmq_la_CFLAGS += -Ilibzmq/include -fvisibility=hidden
 emacs_zmq_la_CPPFLAGS = -DZMQ_BUILD_DRAFT_API=1
 endif
 emacs_zmq_la_SOURCES = socket.c context.c msg.c constants.c util.c core.c poll.c emacs-zmq.c

--- a/src/emacs-zmq.h
+++ b/src/emacs-zmq.h
@@ -8,13 +8,27 @@
 #include "context.h"
 #include "poll.h"
 
-extern int plugin_is_GPL_compatible;
+// https://gcc.gnu.org/wiki/Visibility
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ZMQ_EXPORT __attribute__ ((dllexport))
+  #else
+    #define ZMQ_EXPORT __declspec(dllexport)
+  #endif
+#else
+  #if __GNUC__ >= 4
+    #define ZMQ_EXPORT __attribute__ ((visibility ("default")))
+  #else
+    #define ZMQ_EXPORT
+  #endif
+#endif
 
+ZMQ_EXPORT int plugin_is_GPL_compatible;
 // Defined in constants.c
 extern void
 ezmq_expose_constants();
 
-extern int
+ZMQ_EXPORT int
 emacs_module_init(struct emacs_runtime *ert);
 
 #endif /* __EMACS_ZMQ_H__ */


### PR DESCRIPTION
Similar to the vterm issue https://github.com/akermu/emacs-libvterm/issues/559
zmq crashed my Emacs on the latest master.

Using the same tactic to hide the visibility of the exported symbols like in
https://github.com/akermu/emacs-libvterm/pull/562
fixes the issue for me.