### PR TITLE
Fix utf-8-auto and missing cl-deftype

### DIFF
--- a/zmq.el
+++ b/zmq.el
@@ -49,6 +49,8 @@
 (defvar zmq-current-context nil
   "The context set by the function `zmq-current-context'.")
 
+(cl-deftype zmq-socket () '(satisfies zmq-socket-p))
+
 (defun zmq-current-context ()
   "Return the value of the variable `zmq-current-context' if non-nil.
 Otherwise, create a new `zmq-context', bind it to the

--- a/zmq.el
+++ b/zmq.el
@@ -435,7 +435,7 @@ meant to be called from an Emacs subprocess."
   (if (not noninteractive) (error "Not in a subprocess")
     (read (decode-coding-string
            (base64-decode-string (read-minibuffer ""))
-           'utf-8-unix))))
+           'utf-8-auto))))
 
 (defun zmq-set-subprocess-filter (process event-filter)
   "Set the event filter function for PROCESS.


### PR DESCRIPTION
Due to upcoming changes in Emacs 29.1 utf-8-auto now produces a byte
order mark at the start of strings and no longer matches utf-8-unix.
Emacs is also not equipped to deal with byte order marks appearing on
their own, and will parse them as a symbol with the name \uFEFF (eek).

The end result is that trying to decode utf-8-auto with utf-8-unix in
Emacs 29 will result in an insanity inducing bug where calling read on
a string with a byte order mark (that doesn't render!!!) appears to
produce ... absolutely nothing, which turns out to be the symbol
mentioned above.

https://github.com/emacs-mirror/emacs/commit/cfd2b3504ab5de6eb5f3c7a0784cb447883e1326

Given the absolute nightmare that byte order marks cause in Emacs, I strongly suggest switching everything over to `utf-8-unix` to avoid nasty cases like this in the future, and to save 3 bytes on every message!