### PR TITLE
Prevent stack overflow during subprocess startup in debug mode.

### DIFF
--- a/zmq-tests.el
+++ b/zmq-tests.el
@@ -404,6 +404,27 @@
       (when (process-live-p process)
         (kill-process process)))))
 
+(ert-deftest zmq-subprocess-debug ()
+  (ert-info ("Subprocess starts in debug mode")
+    (let ((process nil)
+          (filter-called nil))
+      (unwind-protect
+          (progn
+            (setq process (zmq-start-process
+                           '(lambda ()
+                              (prin1 (cons 'test-result "alive"))
+                              (zmq-flush 'stdout))
+                           :filter (lambda (event)
+                                     (setq filter-called t)
+                                     (should (equal (cdr event) "alive")))
+                           :debug t))
+            (with-timeout (0.4 nil)
+              (while (not filter-called)
+                (sleep-for 0.01)))
+            (should filter-called))
+        (when (process-live-p process)
+          (kill-process process))))))
+
 (ert-deftest zmq-globrefs ()
   ;; Inspired by https://nullprogram.com/blog/2014/01/27/
   (let ((table (make-hash-table :size 1 :weakness 'value :test 'equal)))

--- a/zmq.el
+++ b/zmq.el
@@ -227,11 +227,12 @@ debugging purposes."
            (signal-hook-function
             (if backtrace
                 (lambda (&rest _)
-                  (setq zmq-backtrace
-                        (with-temp-buffer
-                          (let ((standard-output (current-buffer)))
-                            (backtrace))
-                          (buffer-string))))
+                  (let ((signal-hook-function nil))
+                    (setq zmq-backtrace
+                          (with-temp-buffer
+                            (let ((standard-output (current-buffer)))
+                              (backtrace))
+                            (buffer-string)))))
               signal-hook-function)))
       (condition-case err
           (let ((sexp (eval (zmq-subprocess-read))))


### PR DESCRIPTION
Code called during the `signal-hook-function` can raise handled signals (e.g. `backtrace` autoloads libraries, and those libraries have `defcustom` forms that raise handled `void-variable` signals).  Because the hook is invoked on *every* signal it is important to prevent recursive calls that can easily overflow the stack.

Fixes nnicandro/emacs-zmq#51.